### PR TITLE
feat(status): Implement status command to show portfolio summary

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -1,11 +1,12 @@
 /*
 Copyright © 2025 NAME HERE <EMAIL ADDRESS>
-
 */
 package cmd
 
 import (
 	"fmt"
+	"kk-invest/internal/data"
+	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -13,15 +14,18 @@ import (
 // statusCmd represents the status command
 var statusCmd = &cobra.Command{
 	Use:   "status",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+	Short: "現在の資産状況を表示します",
+	Long:  `現在の総投資額と総保有口数を計算して表示します`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("status called")
+		status, err := data.GetPortfolioStatus()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "資産状況の取得に失敗しました: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("総投資額: %d 円\n", status.TotalInvestment)
+		fmt.Printf("総保有口数: %d 口\n", status.TotalUnits)
 	},
 }
 

--- a/internal/data/database.go
+++ b/internal/data/database.go
@@ -95,3 +95,30 @@ func CloseDB() error {
 	}
 	return nil
 }
+
+type PortfolioStatus struct {
+	TotalInvestment int // 総投資額 (円)
+	TotalUnits      int // 総口数
+	CurrentValue    int // 現在の評価額 (円)
+	UnrealizedPL    int // 評価損益 (円)
+}
+
+func GetPortfolioStatus() (*PortfolioStatus, error) {
+	transactions, err := GetAllTransactions()
+	if err != nil {
+		return nil, err
+	}
+
+	status := &PortfolioStatus{}
+	for _, tx := range transactions {
+		if tx.Type == "buy" {
+			status.TotalInvestment += tx.AmountJPY
+			status.TotalUnits += tx.Units
+		} else if tx.Type == "sell" {
+			status.TotalInvestment -= tx.AmountJPY
+			status.TotalUnits -= tx.Units
+		}
+	}
+
+	return status, nil
+}


### PR DESCRIPTION
Adds the `status` command to display the current portfolio status.

- Implements a `GetPortfolioStatus` function in the data layer to calculate the total investment amount and total units held by iterating through all transactions.
- The `status` command calls this function and prints the summary.
