### PR TITLE
Feature/decide command

### DIFF
--- a/cmd/decide.go
+++ b/cmd/decide.go
@@ -1,0 +1,84 @@
+/*
+Copyright © 2025 NAME HERE <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+	"fmt"
+	"kk-invest/internal/data"
+	"kk-invest/internal/strategy"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// decideCmd represents the decide command
+var decideCmd = &cobra.Command{
+	Use:   "decide",
+	Short: "現在の状況に基づいて売却判断を行います",
+	Long:  `記録されている全取引履歴と価格履歴を分析し, 設定された戦略に基づいて売却すべきかどうか, どのくらい売却すべきかを判断します`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("decide called")
+		transactions, err := data.GetAllTransactions()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "取引履歴の取得に失敗しました: %v\n", err)
+			os.Exit(1)
+		}
+
+		prices, err := data.GetAllDailyPrices()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "価格履歴の取得に失敗しました: %v\n", err)
+			os.Exit(1)
+		}
+		if len(prices) == 0 {
+			fmt.Fprintln(os.Stderr, "価格履歴が存在しません. 基準価格を記録してください")
+		}
+
+		portfolio, err := data.GetPortfolioStatus()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "資産状況の取得に失敗しました: %v\n", err)
+			os.Exit(1)
+		}
+
+		historicalPrices := make([]strategy.DailyPrice, len(prices))
+		for i, p := range prices {
+			historicalPrices[i] = strategy.DailyPrice{
+				Date:  p.Date,
+				Price: p.Price,
+			}
+		}
+
+		input := strategy.AnalysisInput{
+			Transactions:     transactions,
+			HistoricalPrices: historicalPrices,
+			Portfolio:        portfolio,
+		}
+
+		currentStrategy := &strategy.SimpleStrategy{}
+		decision := currentStrategy.Decide(input)
+
+		fmt.Println("💰 売却判断結果 --------------------")
+		if decision.ShouldSell {
+			fmt.Println("売却推奨: はい")
+		} else {
+			fmt.Println("売却推奨: いいえ")
+		}
+		fmt.Printf("売却口数: %d\n", decision.UnitsToSell)
+		fmt.Printf("理由: %s\n", decision.Reason)
+
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(decideCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// decideCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// decideCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/price.go
+++ b/cmd/price.go
@@ -1,0 +1,120 @@
+/*
+Copyright © 2025 NAME HERE <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+	"fmt"
+	"kk-invest/internal/data"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// priceCmd represents the price command
+var priceCmd = &cobra.Command{
+	Use:   "price",
+	Short: "日々の基準価額を管理します",
+	Long:  `日々の基準価額の追加や一覧表示を行います`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("price called")
+	},
+}
+
+var priceAddCmd = &cobra.Command{
+	Use:   "add",
+	Short: "新しい基準価額を追加します",
+	Long: `指定した日付の基準価額 (1万口あたり) を追加します
+		日付を省略した場合: 
+			午前9時まで: 前日
+			それ以降:    当日`,
+	Run: func(cmd *cobra.Command, args []string) {
+		price, _ := cmd.Flags().GetInt("price")
+		if price == 0 {
+			fmt.Fprintln(os.Stderr, "--price を指定する必要があります")
+			os.Exit(1)
+		} else {
+			// 価格のフォーマットチェック (0以上の整数)
+			if price < 0 {
+				fmt.Fprintf(os.Stderr, "価格が不正です: %d\n", price)
+				os.Exit(1)
+			}
+		}
+
+		dateStr, _ := cmd.Flags().GetString("date")
+
+		if dateStr == "" {
+			now := time.Now()
+			if now.Hour() < 9 {
+				dateStr = now.AddDate(0, 0, -1).Format("2006-01-02")
+				fmt.Printf("自動 (前日): %s\n", dateStr)
+			} else {
+				dateStr = now.Format("2006-01-02")
+				fmt.Printf("自動 (当日): %s\n", dateStr)
+			}
+		} else {
+			// 日付のフォーマットチェック
+			if _, err := time.Parse("2006-01-02", dateStr); err != nil {
+				fmt.Fprintf(os.Stderr, "日付が不正です: %v\n", err)
+				os.Exit(1)
+			}
+		}
+
+		if err := data.AddDailyPrice(dateStr, price); err != nil {
+			fmt.Fprintf(os.Stderr, "基準価額の追加に失敗しました: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("基準価額を追加しました: 日付: %s, 価格: %d\n", dateStr, price)
+	},
+}
+
+// priceListCmd represents the list command to list all daily prices
+var priceListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "記録された基準価額の一覧を表示します",
+	Long:  `データベースに保存されている全ての基準価額を, 古い順に表示します`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("price list called")
+		prices, err := data.GetAllDailyPrices()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "基準価額の取得に失敗しました: %v\n", err)
+			os.Exit(1)
+		}
+
+		// 取得した基準価額が一件もなかった場合の処理
+		if len(prices) == 0 {
+			fmt.Println("基準価額が記録されていません")
+			return
+		}
+
+		// ヘッダの表示
+		fmt.Println("日付       | 基準価格 (円/1万口)")
+		fmt.Println("-----------+------------------")
+		// 各基準価額の表示
+		for _, dp := range prices {
+			fmt.Printf("%10s | %16d\n",
+				dp.Date,
+				dp.Price)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(priceCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// priceCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// priceCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	priceCmd.AddCommand(priceAddCmd)
+	priceCmd.AddCommand(priceListCmd)
+
+	priceAddCmd.Flags().String("date", "", "基準価額の日付 (YYYY-MM-DD, 省略時は自動設定)")
+	priceAddCmd.Flags().Int("price", 0, "基準価額 (1万口あたり, 円)")
+}

--- a/internal/strategy/simple.go
+++ b/internal/strategy/simple.go
@@ -1,0 +1,79 @@
+// internal/strategy/simple.go
+package strategy
+
+import (
+	"fmt"
+	"time"
+)
+
+type SimpleStrategy struct{}
+
+func (s *SimpleStrategy) Decide(input AnalysisInput) SellDecision {
+	latestPriceRecord := input.HistoricalPrices[len(input.HistoricalPrices)-1]
+	latestPrice := latestPriceRecord.Price
+	currentUnitPrice := float64(latestPrice) / 10000.0
+
+	var totalBuyJPY, totalSellJPY int
+	for _, tx := range input.Transactions {
+		if tx.Type == "buy" {
+			totalBuyJPY += tx.AmountJPY
+		} else {
+			totalSellJPY += tx.AmountJPY
+		}
+	}
+	targetSellJPY := float64(totalBuyJPY-totalSellJPY) * 0.5
+	unitsToSell := 0
+	if targetSellJPY > 0 {
+		unitsToSell = int(targetSellJPY / currentUnitPrice)
+	}
+
+	// 売却日かどうかの判定
+	today := time.Now()
+	if today.Weekday() != time.Sunday {
+		daysUntilSunday := (7 - int(today.Weekday())) % 7
+		nextSunday := today.AddDate(0, 0, daysUntilSunday)
+
+		reason := fmt.Sprintf("本日 (%s) は売却日ではありません", today.Weekday())
+		if unitsToSell > 0 {
+			reason += fmt.Sprintf("\n次回の売却予定日: %s \n売却予定口数: %d口 (%.0f 円)", nextSunday.Format("2006-01-02"), unitsToSell, targetSellJPY)
+		}
+
+		return SellDecision{
+			ShouldSell:  false,
+			UnitsToSell: 0,
+			Reason:      reason,
+		}
+	}
+
+	if len(input.HistoricalPrices) == 0 {
+		return SellDecision{
+			ShouldSell:  false,
+			UnitsToSell: 0,
+			Reason:      "過去の価格データがありません",
+		}
+	}
+
+	currentValue := float64(input.Portfolio.TotalUnits) * currentUnitPrice
+
+	if currentValue <= float64(input.Portfolio.TotalInvestment) {
+		return SellDecision{
+			ShouldSell:  false,
+			UnitsToSell: 0,
+			Reason:      "現在の評価額が投資元本以下のため, 売却しません (スライド売却)",
+		}
+	}
+
+	if targetSellJPY <= 0 {
+		return SellDecision{
+			ShouldSell:  false,
+			UnitsToSell: 0,
+			Reason:      "売却対象となる残額がありません",
+		}
+	}
+
+	return SellDecision{
+		ShouldSell:  true,
+		UnitsToSell: unitsToSell,
+		Reason:      fmt.Sprintf("本日は売却日です. 現在の評価額が投資元本を上回っているため, %d口 (%.0f 円) を売却します", unitsToSell, targetSellJPY),
+	}
+}

--- a/internal/strategy/strategy.go
+++ b/internal/strategy/strategy.go
@@ -1,0 +1,27 @@
+// internal/strategy/strategy.go
+package strategy
+
+import "kk-invest/internal/data"
+
+type DailyPrice struct {
+	Date  string // 日付 (YYYY-MM-DD)
+	Price int    // その日の終値 (1万口あたりの価格)
+}
+
+// 売却判断アルゴリズムが必要とする全ての情報
+type AnalysisInput struct {
+	Transactions     []data.Transaction    // これまでの全取引履歴
+	HistoricalPrices []DailyPrice          // 過去の価格データ
+	Portfolio        *data.PortfolioStatus // 現在のポートフォリオ状況
+}
+
+type SellDecision struct {
+	ShouldSell  bool   // 売却すべきかどうか
+	UnitsToSell int    // 売却すべき口数
+	Reason      string // 売却判断の理由
+}
+
+// 売却判断アルゴリズムのインターフェース
+type Strategy interface {
+	Decide(input AnalysisInput) SellDecision
+}


### PR DESCRIPTION
Implements the `decide` command to provide a sell recommendation based on a defined strategy.

- Establishes an extensible architecture by creating a `strategy` package with a `Strategy` interface. This allows for future algorithm replacement.
- Implements an initial `SimpleStrategy` based on a weekly (Sunday) sale, checking for unrealized gains, and calculating the sell amount.
- The `decide` command integrates the data layer and strategy layer, fetching all necessary data to make a decision and displaying the result.
- Enhances the user experience by providing information on the next scheduled sale when a sale is not recommended.
